### PR TITLE
Fix flamegraph for profiles with multiple roots

### DIFF
--- a/src/flamegraph.ts
+++ b/src/flamegraph.ts
@@ -51,8 +51,9 @@ export class FlameGraphView implements vscode.CustomReadonlyEditorProvider {
         webviewPanel.webview.onDidReceiveMessage(this.onDidReceiveMessage, undefined, this.context.subscriptions);
         
         document.getContents().then((tree: ProfilerOutputTree) => {
-            tree.setValueMetric("time (inc)", true);
-            webviewPanel.webview.html = this.getHtmlForWebview(tree.getTreeWithSingleRoot());
+            let parentTree = tree.getTreeWithSingleRoot();
+            parentTree.setValueMetric("time (inc)", true);
+            webviewPanel.webview.html = this.getHtmlForWebview(parentTree);
         }, (reason: any) => {
             vscode.window.showErrorMessage(`Error parsing profile: ${reason.message}`);
         });


### PR DESCRIPTION
Fix an issue where FlameGraphs with multiple roots weren't being displayed correctly.