### PR TITLE
remove python 3.7 from testing and add 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         hatchet-version: ['1.3.1', '1.4.0']
         vscode-version: ['1.84.2']
+        exclude:
+          - python-version: '3.12'
+            hatchet-version: '1.3.1'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         hatchet-version: ['1.3.1', '1.4.0']
         vscode-version: ['1.84.2']
     runs-on: ${{ matrix.os }}
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         hatchet-version: ['1.3.1', '1.4.0']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         hatchet-version: ['1.3.1', '1.4.0']
+        exclude:
+          - python-version: '3.12'
+            hatchet-version: '1.3.1'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Performance Profile Viewer uses the Python library
 to parse and process the different profile types.
 You must install it in order to use the extension.
 Currently, the extension has been tested with Hatchet version 1.3.1 to 1.4.0
-and Python 3.7 to 3.11.
+and Python 3.8 to 3.12.
 Assuming there is a valid Python installation, then it can be installed with
 `pip install hatchet==1.4.0`.
 


### PR DESCRIPTION
python 3.7 is EOL so it's ok to remove, also it was causing some issues with macos arm ci